### PR TITLE
Add support for the CellCam Kikker camera.

### DIFF
--- a/acq4/devices/MicroManagerCamera/mmcamera.py
+++ b/acq4/devices/MicroManagerCamera/mmcamera.py
@@ -441,6 +441,7 @@ class MicroManagerCamera(Camera):
         with self.camLock:
             if paramTrans == 'Exposure':
                 val = self.mmc.getExposure(self.camName) # workaround for CellCam
+            else:
                 val = self.mmc.getProperty(self.camName, str(paramTrans))
 
         # coerce to int or float if possible

--- a/acq4/devices/MicroManagerCamera/mmcamera.py
+++ b/acq4/devices/MicroManagerCamera/mmcamera.py
@@ -176,6 +176,8 @@ class MicroManagerCamera(Camera):
                     vals = list(vals)
                 if prop != 'Exposure': # again, workaround...
                     readonly = self.mmc.isPropertyReadOnly(self.camName, prop)
+                else:
+                    readonly = False
                 
 
                 # translate standard properties to the names / formats that we expect

--- a/acq4/devices/MicroManagerCamera/mmcamera.py
+++ b/acq4/devices/MicroManagerCamera/mmcamera.py
@@ -403,7 +403,7 @@ class MicroManagerCamera(Camera):
 
         with self.camLock:
             for param, value in setParams:
-                if param == 'Exposure': # workaround for CellCam - call to setExposure(), not getProperty()
+                if param == 'Exposure' and self.camName == "CellCam": # workaround for CellCam - call to setExposure(), not getProperty()
                     self.mmc.setExposure(self.camName, value)
                 else:
                     self.mmc.setProperty(self.camName, str(param), str(value))

--- a/acq4/devices/MicroManagerCamera/mmcamera.py
+++ b/acq4/devices/MicroManagerCamera/mmcamera.py
@@ -69,8 +69,13 @@ class MicroManagerCamera(Camera):
         if deviceName not in allDevices:
             raise ValueError("Device name '%s' is not valid for adapter '%s'. Options are: %s" % (
                 deviceName, adapterName, allDevices))
-
+        if deviceName == 'CellCam':
+            self.camName = 'CellCam' # load.Device() for CellCam needs to have 'CellCam' as device name
         self.mmc.loadDevice(self.camName, adapterName, deviceName)
+        
+        # the 'Camera ID' property is not prefilled after loadDevice(). Need to assign it:
+        if self.camName == 'CellCam':
+            self.mmc.setProperty(self.camName, 'Camera ID', ''.join(self.mmc.getAllowedPropertyValues('CellCam', 'Camera ID'))) 
         self.mmc.initializeDevice(self.camName)
 
         self._readAllParams()
@@ -152,21 +157,26 @@ class MicroManagerCamera(Camera):
         with self.camLock:
             params = OrderedDict([(n, None) for n in defaultParams])
 
-            properties = self.mmc.getDevicePropertyNames(self.camName)
+            properties = self.mmc.getDevicePropertyNames(self.camName) + ('Exposure',) # because the CellCam driver didn't present the exposure as a property, need to add it with a getExposure() call
             for prop in properties:
                 vals = self.mmc.getAllowedPropertyValues(self.camName, prop)
                 if vals == ():
-                    if self.mmc.hasPropertyLimits(self.camName, prop):
-                        vals = (
-                            self.mmc.getPropertyLowerLimit(self.camName, prop),
-                            self.mmc.getPropertyUpperLimit(self.camName, prop),
-                        )
+                    if prop != 'Exposure': # workaround for exposure working
+                        if self.mmc.hasPropertyLimits(self.camName, prop):
+                            vals = (
+                                self.mmc.getPropertyLowerLimit(self.camName, prop),
+                                self.mmc.getPropertyUpperLimit(self.camName, prop),
+                            )
+                        else:
+                            # just guess..
+                            vals = (1e-6, 1e3)
                     else:
-                        # just guess..
-                        vals = (1e-6, 1e3)
+                        vals = (1, 100) # sensible range of exposure values...
                 else:
                     vals = list(vals)
-                readonly = self.mmc.isPropertyReadOnly(self.camName, prop)
+                if prop != 'Exposure': # again, workaround...
+                    readonly = self.mmc.isPropertyReadOnly(self.camName, prop)
+                
 
                 # translate standard properties to the names / formats that we expect
                 if prop == 'Exposure':
@@ -391,7 +401,10 @@ class MicroManagerCamera(Camera):
 
         with self.camLock:
             for param, value in setParams:
-                self.mmc.setProperty(self.camName, str(param), str(value))
+                if param == 'Exposure': # workaround for CellCam - call to setExposure(), not getProperty()
+                    self.mmc.setExposure(self.camName, value)
+                else:
+                    self.mmc.setProperty(self.camName, str(param), str(value))
 
     def getParams(self, params=None):
         if params is None:
@@ -426,7 +439,9 @@ class MicroManagerCamera(Camera):
             'bitDepth': 'PixelType',
         }.get(param, param)
         with self.camLock:
-            val = self.mmc.getProperty(self.camName, str(paramTrans))
+            if paramTrans == 'Exposure':
+                val = self.mmc.getExposure(self.camName) # workaround for CellCam
+                val = self.mmc.getProperty(self.camName, str(paramTrans))
 
         # coerce to int or float if possible
         try:

--- a/acq4/devices/MicroManagerCamera/mmcamera.py
+++ b/acq4/devices/MicroManagerCamera/mmcamera.py
@@ -442,6 +442,7 @@ class MicroManagerCamera(Camera):
             if paramTrans == 'Exposure':
                 val = self.mmc.getExposure(self.camName) # workaround for CellCam
             else:
+            else:
                 val = self.mmc.getProperty(self.camName, str(paramTrans))
 
         # coerce to int or float if possible

--- a/acq4/devices/MicroManagerCamera/mmcamera.py
+++ b/acq4/devices/MicroManagerCamera/mmcamera.py
@@ -441,7 +441,7 @@ class MicroManagerCamera(Camera):
             'bitDepth': 'PixelType',
         }.get(param, param)
         with self.camLock:
-            if paramTrans == 'Exposure':
+            if paramTrans == 'Exposure' and self.camName == "CellCam":
                 val = self.mmc.getExposure(self.camName) # workaround for CellCam
             else:
             else:


### PR DESCRIPTION
Hi,

I added support for the CellCam Kikker camera. The trick was to add a getExposure() call because the MicroManager driver does not expose this as a property. The other changes are just downstream from that. Everything seems to be working on my end. Hope this helps!

Marcin