### PR TITLE
Pass health-model config + score cutoffs to the cell annotation tool

### DIFF
--- a/acq4/modules/AutomationDebug/detection.py
+++ b/acq4/modules/AutomationDebug/detection.py
@@ -41,6 +41,24 @@ def _annotation_save_dir(manager) -> Path | None:
     return None
 
 
+def _health_model_config(manager) -> dict:
+    """Health-model paths and score cutoffs from the global ``misc`` config.
+
+    Shared by neuron detection and the annotation-tool launch so both use the same
+    configured models. ``scoreCutoffs`` is an ascending list mapping a ranking
+    model's raw scores onto the 0-5 rating bins (see
+    acq4_automation.compute_score_cutoffs); None falls back to equal-width bins.
+    """
+    misc = manager.config.get("misc", {})
+    return {
+        "segmenter": misc.get("segmenterPath", None),
+        "autoencoder": misc.get("autoencoderPath", None),
+        "classifier": misc.get("classifierPath", None),
+        "resnet_classifier": misc.get("resnetClassifierPath", None),
+        "score_cutoffs": misc.get("scoreCutoffs", None),
+    }
+
+
 class CellDetector:
     def __init__(self, window: AutomationDebugWindow):
         self._window = window
@@ -94,10 +112,11 @@ class CellDetector:
 
         pixel_size = win.cameraDevice.getPixelSize()[0]  # Used for both real and mock
         man = win.module.manager
-        segmenter = man.config.get("misc", {}).get("segmenterPath", None)
-        autoencoder = man.config.get("misc", {}).get("autoencoderPath", None)
-        classifier = man.config.get("misc", {}).get("classifierPath", None)
-        resnet_classifier = man.config.get("misc", {}).get("resnetClassifierPath", None)
+        models = _health_model_config(man)
+        segmenter = models["segmenter"]
+        autoencoder = models["autoencoder"]
+        classifier = models["classifier"]
+        resnet_classifier = models["resnet_classifier"]
         step_z = 1 * µm  # can be updated by mock metadata
         depth = win.cameraDevice.getFocusDepth()
         classification_stack = None  # Initialize as None
@@ -224,6 +243,9 @@ class CellDetector:
 
             if win._annotation_tool is not None:
                 win._annotation_tool.close()
+            # Same configured health models as detection, plus score cutoffs, so the
+            # annotation tool re-scores the detected cells and bins them consistently.
+            models = _health_model_config(win.module.manager)
             win._annotation_tool = open_annotation_tool_with_detections(
                 stack=stack,
                 cell_centers_ijk=centers_ijk,
@@ -234,6 +256,10 @@ class CellDetector:
                 transpose_display=True,  # stack is (n_frames, Y, X) after .T; row-major matches camera module orientation
                 custom_buttons=[("Center Camera", _center_camera_on_cell)],
                 save_dir=_annotation_save_dir(win.module.manager),
+                classifier=models["classifier"],
+                autoencoder=models["autoencoder"],
+                resnet_classifier=models["resnet_classifier"],
+                score_cutoffs=models["score_cutoffs"],
             )
 
             # from acq4_automation.object_detection import NeuronBoxViewer

--- a/acq4/modules/AutomationDebug/tests/test_detection_config.py
+++ b/acq4/modules/AutomationDebug/tests/test_detection_config.py
@@ -1,0 +1,41 @@
+"""Tests for AutomationDebug health-model config reading.
+
+Cover that _health_model_config pulls the model paths and score cutoffs from the
+global ``misc`` config and defaults each to None when unset.
+"""
+
+from types import SimpleNamespace
+
+from acq4.modules.AutomationDebug.detection import _health_model_config
+
+
+def test_health_model_config_reads_misc():
+    manager = SimpleNamespace(
+        config={
+            "misc": {
+                "segmenterPath": "/s",
+                "autoencoderPath": "/a",
+                "classifierPath": "/c",
+                "resnetClassifierPath": "/r",
+                "scoreCutoffs": [0.1, 0.2, 0.3, 0.4, 0.5],
+            }
+        }
+    )
+    assert _health_model_config(manager) == {
+        "segmenter": "/s",
+        "autoencoder": "/a",
+        "classifier": "/c",
+        "resnet_classifier": "/r",
+        "score_cutoffs": [0.1, 0.2, 0.3, 0.4, 0.5],
+    }
+
+
+def test_health_model_config_defaults_to_none():
+    manager = SimpleNamespace(config={})
+    assert _health_model_config(manager) == {
+        "segmenter": None,
+        "autoencoder": None,
+        "classifier": None,
+        "resnet_classifier": None,
+        "score_cutoffs": None,
+    }

--- a/config/example/default.cfg
+++ b/config/example/default.cfg
@@ -108,6 +108,23 @@ misc:
     ## subdirectory of the data storage directory.
     # cellAnnotationDir: '/home/user/data/cell_annotations'
 
+    ## Health-model paths used by the AutomationDebug "Detect Neurons" workflow for
+    ## both detection and the per-cell predictions shown in the annotation tool.
+    ## Provide either a resnetClassifierPath (scores crops end-to-end) or an
+    ## autoencoderPath + classifierPath pair; resnetClassifierPath takes precedence.
+    # segmenterPath: '/path/to/segmenter'
+    # autoencoderPath: '/path/to/autoencoder.pt'
+    # classifierPath: '/path/to/classifier.joblib'
+    # resnetClassifierPath: '/path/to/resnet-classifier.pt'
+
+    ## Ascending score cutoffs (one fewer than the 6 rating bins, i.e. 5) that map a
+    ## ranking model's raw scores onto the 0-5 rating scale in the annotation tool.
+    ## Health models usually only rank cells, so raw scores aren't calibrated
+    ## probabilities; derive cutoffs for a given model+corpus with
+    ## `python -m acq4_automation.compute_score_cutoffs <corpus> --resnet-classifier <model>`.
+    ## If unset, scores are binned with fixed equal-width bins.
+    # scoreCutoffs: [0.000136, 0.001249, 0.012659, 0.073959, 0.148094]
+
 configurations:
     User_1:
         storageDir: '/home/user/data/user1'


### PR DESCRIPTION
## What

When AutomationDebug's "Detect Neurons" workflow opens the cell annotation tool, it now passes the configured health models **and** a new `misc.scoreCutoffs` setting through to the tool, so each detected cell gets a predicted health score binned onto the 0–5 rating scale (matching the manual ratings, with agreement highlighting).

Previously the models were read only for detection; the annotation tool opened with no predictions.

## Changes

- **`detection.py`**: new `_health_model_config(manager)` centralizes reading `misc.{segmenter,autoencoder,classifier,resnetClassifier}Path` and the new `misc.scoreCutoffs`. Used by both `_detectNeuronsZStack` (detection) and `_handleDetectResults` (annotation-tool launch), so the two stay in sync. The launch now forwards `classifier`/`autoencoder`/`resnet_classifier`/`score_cutoffs` to `open_annotation_tool_with_detections`.
- **`config/example/default.cfg`**: document the model-path keys and the new `scoreCutoffs` key (next to the existing `cellAnnotationDir`).
- **tests**: `_health_model_config` unit tests (reads `misc`, defaults to None).

## Config

```
misc:
    resnetClassifierPath: '/path/to/resnet-classifier'   # or autoencoderPath + classifierPath
    scoreCutoffs: [0.000136, 0.001249, 0.012659, 0.073959, 0.148094]
```

`scoreCutoffs` maps a ranking model's uncalibrated scores onto the rating bins (health models rank cells; their raw scores aren't calibrated probabilities). Derive them per model+corpus with:

```
python -m acq4_automation.compute_score_cutoffs <corpus> --resnet-classifier <model>
```

## Dependency

Requires the matching **acq4-automation** change that adds `classifier`/`autoencoder`/`resnet_classifier`/`score_cutoffs` to `open_annotation_tool_with_detections` (AllenInstitute/acq4-automation PR #12). Without it, the new kwargs will be rejected.

## Testing

- `_health_model_config` unit tests pass.
- `detection.py` compiles; `config/example/default.cfg` parses via `pyqtgraph.configfile`; the `scoreCutoffs` list round-trips as a list of floats.
- Full UI flow not auto-tested (AutomationDebug is a hardware/Qt GUI module with no test harness); change is config plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)