### PR TITLE
feat: acq4-mcp — MCP for executing code on a running ACQ4

### DIFF
--- a/acq4/mcp/KNOWN_ISSUES.md
+++ b/acq4/mcp/KNOWN_ISSUES.md
@@ -2,8 +2,10 @@
 
 ## teleprox transport framing corrupts under concurrent / sustained load (blocker for production)
 
-**Status:** open. The MCP is safe for gentle, single-threaded, interactive use, but is
-**not yet production-safe** on rigs where a crash is costly.
+**Status:** open. Tracked upstream at
+[campagnola/teleprox#40](https://github.com/campagnola/teleprox/issues/40). The MCP is safe
+for gentle, single-threaded, interactive use, but is **not yet production-safe** on rigs
+where a crash is costly.
 
 ### Symptom
 

--- a/acq4/mcp/KNOWN_ISSUES.md
+++ b/acq4/mcp/KNOWN_ISSUES.md
@@ -1,0 +1,79 @@
+# acq4-mcp — known issues
+
+## teleprox transport framing corrupts under concurrent / sustained load (blocker for production)
+
+**Status:** open. The MCP is safe for gentle, single-threaded, interactive use, but is
+**not yet production-safe** on rigs where a crash is costly.
+
+### Symptom
+
+While the MCP drives a running ACQ4, one of two things happens:
+
+- **Recoverable:** ACQ4 logs `ValueError: Invalid RPC message: expected 6 parts, got N`
+  from `teleprox/server.py` `run_forever` → `_read_one`. This exception is **unhandled**
+  and terminates the RPCServer's `run_forever` thread, so the teleprox server (and
+  MockClamp's `local_server="threaded"` callback server) goes deaf. The ACQ4 process keeps
+  running but no longer answers teleprox.
+- **Fatal:** a libzmq assertion `Assertion failed: false (src/object.cpp:142)` aborts the
+  whole ACQ4 process with `SIGABRT`. This was the original crash, seen on the very first
+  MCP call.
+
+Both are the same underlying defect showing different faces.
+
+### Root cause
+
+Concurrent access to a single teleprox/zmq socket. libzmq sockets are not thread-safe;
+when a socket's multipart send/receive is not atomic with respect to other access, frames
+from different messages interleave. Captured evidence (from a single client thread's
+socket):
+
+```
+expected 6 parts, got 2: [<caller>, {'module': 'acq4.mcp.host'}]   # a message tail
+expected 6 parts, got 3: [<caller>, 'ping', 'auto']                # a message head
+expected 6 parts, got 1: [b'import']                               # a lone action frame
+```
+
+A `ping` frame and a `call`/`import` frame from the same caller interleave — the multipart
+sequences of two teleprox messages are split apart.
+
+### Why the MCP exposes it (it does not cause it)
+
+ACQ4 already runs several teleprox/zmq endpoints on the process-global
+`zmq.Context.instance()`: the `--teleprox` RPCServer, the logging `LogServer`, and (per
+device config) an RPCClient + threaded callback server for subprocess-backed devices such
+as **MockClamp** (`MockClamp.py` calls `teleprox.start_process(local_server="threaded")`).
+Before the MCP, nothing ever connected to the `--teleprox` RPCServer, so its thread sat
+idle with no contention. The MCP wakes that thread and drives requests; under concurrency
+or sustained throughput the transport corrupts.
+
+### What was ruled out
+
+- **Not `host.execute` / stdout redirection.** 400+ controlled `execute` round-trips under
+  concurrent stdout/stderr/logging stress (with `log_stdio=True`, i.e. zmq-backed stdout)
+  never crashed. `exec("1+1")` on the handler thread has no path to the failing sockets.
+- **Not the imaging / Visualize3D path.** The camera/record threads use no teleprox/zmq;
+  the record-thread appearing in the original crash stack was incidental.
+- **Not fixed by serializing the MCP client.** Routing every MCP teleprox call through a
+  single dedicated worker thread (one client socket, serialized) still corrupts under
+  sustained concurrent load (4 caller threads → 1 executor, plain `execute("1+1")`, no
+  nested calls). The contention is inside the teleprox transport, below the MCP layer.
+
+### Reproduction
+
+1. Launch: `python -m acq4 -x --teleprox 38750 -c config/mock/default.cfg -m Camera -m Visualize3D -m AutomationDebug`
+2. From several threads, hammer `ConnectionManager.execute("1 + 1")` (or a single thread
+   doing device access that proxies to the MockClamp child, e.g.
+   `man.getDevice('Clamp1').getState()`).
+3. Within seconds, ACQ4 logs `Invalid RPC message` and its RPCServer thread(s) die; the
+   `object.cpp:142` abort appears intermittently.
+
+### Candidate fixes (in teleprox — a separate repo; not yet done)
+
+- Make teleprox's multipart socket send/receive atomic (per-socket lock), and/or strictly
+  confine each socket to one thread including ping/reconnect probes.
+- Make `run_forever` resilient: a malformed/partial message should be logged and skipped,
+  not allowed to kill the server thread. This alone would prevent the "server goes deaf"
+  cascade (but not the fatal libzmq assertion).
+
+Until teleprox is hardened, avoid driving a production ACQ4's `--teleprox` server with
+concurrent or high-rate MCP traffic.

--- a/acq4/mcp/README.md
+++ b/acq4/mcp/README.md
@@ -4,6 +4,13 @@ An [MCP](https://modelcontextprotocol.io) server that lets an AI client (Claude 
 Claude Code, etc.) inspect and drive a **running** ACQ4 instance by executing Python
 inside the ACQ4 process. It connects over ACQ4's existing teleprox `RPCServer`.
 
+> **Status — not yet production-safe.** Concurrent or high-rate MCP traffic corrupts the
+> teleprox transport, which can kill ACQ4's RPCServer thread or (intermittently) abort the
+> whole process with a libzmq assertion. This is a teleprox-level bug exposed — not caused
+> — by the MCP, and is **not** fixed by the MCP's client-side serialization. See
+> [KNOWN_ISSUES.md](KNOWN_ISSUES.md). Safe for gentle, single-threaded, interactive use;
+> do not point it at a production rig where a crash is costly until teleprox is hardened.
+
 ## How it works
 
 ```

--- a/acq4/mcp/README.md
+++ b/acq4/mcp/README.md
@@ -1,0 +1,104 @@
+# acq4-mcp
+
+An [MCP](https://modelcontextprotocol.io) server that lets an AI client (Claude Desktop,
+Claude Code, etc.) inspect and drive a **running** ACQ4 instance by executing Python
+inside the ACQ4 process. It connects over ACQ4's existing teleprox `RPCServer`.
+
+## How it works
+
+```
+AI client  --stdio-->  acq4-mcp server  --teleprox TCP-->  ACQ4 process
+           (mcp SDK)   (this package)                      (acq4.mcp.host)
+```
+
+- `acq4/mcp/host.py` runs **inside** ACQ4 (where the Manager and Qt GUI live) and does the
+  actual work. It has no dependency on the `mcp` SDK, so it ships and imports on every
+  ACQ4 install.
+- `acq4/mcp/connection.py` is the client-side teleprox connection manager.
+- `acq4/mcp/server.py` is the thin FastMCP stdio server. It imports the `mcp` SDK, so only
+  the machine running the server needs the extra installed.
+
+## Setup
+
+1. Install the MCP extra on the machine that will run the server:
+
+   ```
+   pip install acq4[mcp]
+   ```
+
+2. Start ACQ4 with a teleprox server:
+
+   ```
+   acq4 --teleprox 5000
+   ```
+
+   With a bare `--teleprox` (no port) ACQ4 picks a random port and prints
+   `Teleprox server listening on tcp://127.0.0.1:<port>` at startup.
+
+3. Register the MCP server with your client. Example `mcpServers` config:
+
+   ```json
+   {
+     "mcpServers": {
+       "acq4": {
+         "command": "acq4-mcp"
+       }
+     }
+   }
+   ```
+
+4. In the conversation, connect to the rig: call `connect_acq4(port=5000)`. The port is
+   supplied at runtime (not baked into the config), so when ACQ4 restarts on a different
+   port you just call `connect_acq4` again -- no need to restart the MCP server.
+
+### Remote rigs
+
+ACQ4 binds its teleprox server to `127.0.0.1`. To reach a rig on another machine, open an
+SSH tunnel and connect to the local end, e.g.:
+
+```
+ssh -L 5000:127.0.0.1:5000 user@rig-host
+```
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `connect_acq4(port, host="127.0.0.1")` | Connect to a running ACQ4 and make it the active target. Returns an identity/sanity summary. |
+| `execute_code(code, gui_thread=False, timeout=30.0, port=None, host=None)` | Execute arbitrary Python in the ACQ4 process. |
+| `list_devices(port=None, host=None)` | Device name -> class mapping (read-only). |
+| `list_modules(port=None, host=None)` | Loaded and configured module names (read-only). |
+| `manager_state(port=None, host=None)` | Storage dirs, device count, config keys (read-only). |
+| `get_log(lines=50, port=None, host=None)` | Tail of the ACQ4 log file (read-only). |
+
+`execute_code` runs in a fresh namespace each call (nothing persists between calls), seeded
+with `man` (the ACQ4 Manager) and `acq4`. It returns captured stdout/stderr, the value of a
+trailing expression, and any traceback.
+
+## GUI thread: `gui_thread=False` vs `gui_thread=True`
+
+This is the central hazard. Choosing wrong can **crash or freeze** ACQ4.
+
+- **`gui_thread=False` (default)** -- code runs off the GUI thread. Use this for anything
+  **blocking or long-running**: device/stage/pipette moves, `.wait()`, acquisitions,
+  `sleep`, patch state changes. Running such code on the GUI thread would **freeze or
+  deadlock** the entire ACQ4 application.
+- **`gui_thread=True`** -- code is marshalled onto the Qt GUI thread and blocks until it
+  returns. Use this **only** for fast, non-blocking access to Qt widgets/objects or GUI
+  state. Touching Qt objects from another thread risks a **segfault** -- but never run
+  blocking work on the GUI thread.
+
+Rule of thumb: if it touches a Qt widget and returns immediately, `gui_thread=True`.
+Everything else (especially anything that moves hardware or waits) stays `gui_thread=False`.
+
+## Safety: do not mutate without approval
+
+The read-only tools (`list_devices`, `list_modules`, `manager_state`, `get_log`) are safe to
+call freely. `execute_code` can do anything Python can do in the ACQ4 process. There is no
+enforcement layer -- no code can reliably tell whether arbitrary Python mutates state -- so
+this is a discipline the agent must follow:
+
+> Inspect freely. Obtain **explicit user approval** before executing anything that changes
+> running state or moves hardware: stage/pipette moves, pressure changes, clamp mode
+> changes, starting tasks or acquisitions, or writing config/data. When in doubt, treat it
+> as mutating and ask first.

--- a/acq4/mcp/__init__.py
+++ b/acq4/mcp/__init__.py
@@ -1,0 +1,5 @@
+"""MCP integration for ACQ4: execute code and inspect a running instance over teleprox.
+
+This package must import cleanly on every ACQ4 install; the optional `mcp` SDK is
+only imported by `acq4.mcp.server` (the stdio MCP process), never at package import.
+"""

--- a/acq4/mcp/connection.py
+++ b/acq4/mcp/connection.py
@@ -6,6 +6,9 @@ mid-session without restarting the MCP server. This module has no dependency on 
 `mcp` SDK, so the connection logic is unit-testable on its own.
 """
 
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
 from teleprox import RPCClient
 
 DEFAULT_HOST = "127.0.0.1"
@@ -19,12 +22,46 @@ class NotConnectedError(RuntimeError):
 class ConnectionManager:
     """Resolve, cache, and call the ACQ4-side host module over teleprox."""
 
-    def __init__(self, host_module_provider=None):
+    def __init__(self, host_module_provider=None, serialize=True):
         # host_module_provider(host, port) -> proxy to acq4.mcp.host on that target.
         # Injectable so the manager's resolution/delegation logic is testable without
         # a live teleprox connection.
         self._active = None  # (host, port) or None
         self._host_module_provider = host_module_provider or self._teleprox_host_module
+
+        # teleprox/zmq sockets are not thread-safe: two threads touching one socket
+        # corrupt its multipart framing (recoverable) or trip a libzmq assertion
+        # (fatal). Route every teleprox operation through a single dedicated worker
+        # thread so exactly one client socket is ever used, and only by that thread.
+        self._executor = (
+            ThreadPoolExecutor(max_workers=1, thread_name_prefix="acq4-mcp")
+            if serialize
+            else None
+        )
+        self._local = threading.local()
+
+    def _run(self, fn, *args, **kwargs):
+        """Run *fn* on the dedicated worker thread and block for its result.
+
+        Reentrant calls (already on the worker) run inline to avoid self-deadlock on
+        the single worker.
+        """
+        if self._executor is None or getattr(self._local, "in_worker", False):
+            return fn(*args, **kwargs)
+
+        def wrapped():
+            self._local.in_worker = True
+            try:
+                return fn(*args, **kwargs)
+            finally:
+                self._local.in_worker = False
+
+        return self._executor.submit(wrapped).result()
+
+    def close(self):
+        """Shut down the worker thread."""
+        if self._executor is not None:
+            self._executor.shutdown(wait=True)
 
     @property
     def active_address(self):
@@ -54,6 +91,9 @@ class ConnectionManager:
 
     def connect(self, port, host=DEFAULT_HOST):
         """Connect to an ACQ4 target, make it active, and return its instance_info."""
+        return self._run(self._connect, port, host)
+
+    def _connect(self, port, host):
         info = dict(self._host_module(host, port).instance_info(_return_type="value"))
         self._active = (host, port)
         info["host"] = host
@@ -62,6 +102,9 @@ class ConnectionManager:
 
     def execute(self, code, gui_thread=False, timeout=30.0, port=None, host=None):
         """Run *code* on the resolved target and return the host result dict."""
+        return self._run(self._execute, code, gui_thread, timeout, port, host)
+
+    def _execute(self, code, gui_thread, timeout, port, host):
         host, port = self._resolve(host, port)
         return self._host_module(host, port).execute(
             code, gui_thread, _return_type="value", _timeout=timeout
@@ -69,20 +112,32 @@ class ConnectionManager:
 
     def list_devices(self, port=None, host=None):
         """Return the target's device-name -> class-name mapping."""
+        return self._run(self._list_devices, port, host)
+
+    def _list_devices(self, port, host):
         host, port = self._resolve(host, port)
         return self._host_module(host, port).list_devices(_return_type="value")
 
     def list_modules(self, port=None, host=None):
         """Return the target's loaded and defined module names."""
+        return self._run(self._list_modules, port, host)
+
+    def _list_modules(self, port, host):
         host, port = self._resolve(host, port)
         return self._host_module(host, port).list_modules(_return_type="value")
 
     def manager_state(self, port=None, host=None):
         """Return the target's Manager storage/config summary."""
+        return self._run(self._manager_state, port, host)
+
+    def _manager_state(self, port, host):
         host, port = self._resolve(host, port)
         return self._host_module(host, port).manager_state(_return_type="value")
 
     def get_log(self, lines=50, port=None, host=None):
         """Return the tail of the target's ACQ4 log file."""
+        return self._run(self._get_log, lines, port, host)
+
+    def _get_log(self, lines, port, host):
         host, port = self._resolve(host, port)
         return self._host_module(host, port).get_log(lines, _return_type="value")

--- a/acq4/mcp/connection.py
+++ b/acq4/mcp/connection.py
@@ -1,0 +1,88 @@
+"""Client-side teleprox connection manager for the acq4-mcp server.
+
+Holds teleprox clients (one per thread, per address, via RPCClient.get_client) and
+tracks the active ACQ4 target, so the teleprox port can be supplied -- or changed --
+mid-session without restarting the MCP server. This module has no dependency on the
+`mcp` SDK, so the connection logic is unit-testable on its own.
+"""
+
+from teleprox import RPCClient
+
+DEFAULT_HOST = "127.0.0.1"
+HOST_MODULE = "acq4.mcp.host"
+
+
+class NotConnectedError(RuntimeError):
+    """Raised when a tool needs an ACQ4 target but none is active and none was given."""
+
+
+class ConnectionManager:
+    """Resolve, cache, and call the ACQ4-side host module over teleprox."""
+
+    def __init__(self, host_module_provider=None):
+        # host_module_provider(host, port) -> proxy to acq4.mcp.host on that target.
+        # Injectable so the manager's resolution/delegation logic is testable without
+        # a live teleprox connection.
+        self._active = None  # (host, port) or None
+        self._host_module_provider = host_module_provider or self._teleprox_host_module
+
+    @property
+    def active_address(self):
+        """Return the active target as "host:port", or None if not connected."""
+        if self._active is None:
+            return None
+        return f"{self._active[0]}:{self._active[1]}"
+
+    def _teleprox_host_module(self, host, port):
+        """Return a proxy to acq4.mcp.host on the given target via teleprox."""
+        client = RPCClient.get_client(f"tcp://{host}:{port}")
+        return client._import(HOST_MODULE)
+
+    def _host_module(self, host, port):
+        """Return the host-module proxy for the given target."""
+        return self._host_module_provider(host, port)
+
+    def _resolve(self, host, port):
+        """Return (host, port) from an explicit override or the active connection."""
+        if port is None:
+            if self._active is None:
+                raise NotConnectedError(
+                    "No active ACQ4 connection. Call connect_acq4(port) first, or pass a port."
+                )
+            return self._active
+        return (host or DEFAULT_HOST, port)
+
+    def connect(self, port, host=DEFAULT_HOST):
+        """Connect to an ACQ4 target, make it active, and return its instance_info."""
+        info = dict(self._host_module(host, port).instance_info(_return_type="value"))
+        self._active = (host, port)
+        info["host"] = host
+        info["port"] = port
+        return info
+
+    def execute(self, code, gui_thread=False, timeout=30.0, port=None, host=None):
+        """Run *code* on the resolved target and return the host result dict."""
+        host, port = self._resolve(host, port)
+        return self._host_module(host, port).execute(
+            code, gui_thread, _return_type="value", _timeout=timeout
+        )
+
+    def list_devices(self, port=None, host=None):
+        """Return the target's device-name -> class-name mapping."""
+        host, port = self._resolve(host, port)
+        return self._host_module(host, port).list_devices(_return_type="value")
+
+    def list_modules(self, port=None, host=None):
+        """Return the target's loaded and defined module names."""
+        host, port = self._resolve(host, port)
+        return self._host_module(host, port).list_modules(_return_type="value")
+
+    def manager_state(self, port=None, host=None):
+        """Return the target's Manager storage/config summary."""
+        host, port = self._resolve(host, port)
+        return self._host_module(host, port).manager_state(_return_type="value")
+
+    def get_log(self, lines=50, port=None, host=None):
+        """Return the tail of the target's ACQ4 log file."""
+        host, port = self._resolve(host, port)
+        return self._host_module(host, port).get_log(lines, _return_type="value")

--- a/acq4/mcp/host.py
+++ b/acq4/mcp/host.py
@@ -1,0 +1,194 @@
+"""ACQ4-side helpers imported over teleprox by the acq4-mcp server.
+
+Runs inside the ACQ4 process, where the Manager and Qt GUI live. This module has no
+dependency on the `mcp` SDK so it imports on every ACQ4 install. `execute` runs
+arbitrary code against the live instance; the remaining functions are read-only
+inspection helpers.
+"""
+
+import ast
+import contextlib
+import io
+import traceback
+
+
+def _build_namespace() -> dict:
+    """Return a fresh globals dict seeded with `man` and `acq4`.
+
+    `man` is the running Manager, or None if no Manager has been created yet (so that
+    code not needing the Manager still runs).
+    """
+    import acq4
+
+    try:
+        man = acq4.getManager()
+    except Exception:
+        man = None
+    return {"__name__": "__acq4_mcp__", "acq4": acq4, "man": man}
+
+
+def _exec_and_capture(code: str, namespace: dict) -> dict:
+    """Exec *code* in *namespace*, capturing stdout/stderr and the trailing expression.
+
+    If the final statement is an expression, its value is evaluated and returned as
+    `result` (via repr); otherwise `result` is None. Exceptions are caught and returned
+    as a formatted `traceback` string rather than propagated.
+    """
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    result_repr = None
+    tb = None
+
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        try:
+            parsed = ast.parse(code)
+            trailing_expr = None
+            if parsed.body and isinstance(parsed.body[-1], ast.Expr):
+                trailing_expr = ast.Expression(parsed.body.pop().value)
+
+            exec(compile(parsed, "<acq4-mcp>", "exec"), namespace)
+            if trailing_expr is not None:
+                value = eval(compile(trailing_expr, "<acq4-mcp>", "eval"), namespace)
+                if value is not None:
+                    result_repr = repr(value)
+        except BaseException:
+            tb = traceback.format_exc()
+
+    return {
+        "stdout": stdout.getvalue(),
+        "stderr": stderr.getvalue(),
+        "result": result_repr,
+        "traceback": tb,
+    }
+
+
+def execute(code: str, gui_thread: bool = False) -> dict:
+    """Execute *code* against the live ACQ4 instance and return a result dict.
+
+    The dict has keys: stdout, stderr, result (repr of the trailing expression or None),
+    and traceback (a formatted string, or None on success).
+
+    A fresh namespace is built for every call (no state persists between calls), seeded
+    with `man` (the Manager) and `acq4`.
+
+    gui_thread selects where the code runs:
+
+    * gui_thread=False (default): run on the calling (teleprox handler) thread. Use this
+      for anything blocking or long-running -- device moves, waits, acquisitions, sleeps.
+      Running such code on the GUI thread would freeze or deadlock ACQ4.
+    * gui_thread=True: marshal onto the Qt GUI thread via run_in_gui_thread, blocking
+      until it returns. Use this ONLY for fast, non-blocking access to Qt widgets/objects
+      or GUI state. Touching Qt objects from another thread risks a segfault.
+    """
+    namespace = _build_namespace()
+
+    def run():
+        return _exec_and_capture(code, namespace)
+
+    if gui_thread:
+        from acq4.util import task
+
+        return task.run_in_gui_thread(run)
+    return run()
+
+
+def _manager():
+    """Return the running Manager (raises RuntimeError if none has been created)."""
+    import acq4
+
+    return acq4.getManager()
+
+
+def instance_info() -> dict:
+    """Return a lightweight identity/sanity summary of this ACQ4 instance.
+
+    Tolerant of there being no Manager yet (the teleprox server can start before the
+    Manager is created), so it is safe to call immediately after connecting.
+    """
+    import socket
+
+    import acq4
+
+    info = {
+        "acq4_version": getattr(acq4, "__version__", None),
+        "hostname": socket.gethostname(),
+        "has_manager": False,
+        "base_dir": None,
+        "device_count": None,
+    }
+    try:
+        man = acq4.getManager()
+    except Exception:
+        return info
+    info["has_manager"] = True
+    info["base_dir"] = _dir_str(man.getBaseDir())
+    info["device_count"] = len(man.listDevices())
+    return info
+
+
+def _dir_str(dir_handle):
+    """Return a printable path for a DirHandle, or None."""
+    if dir_handle is None:
+        return None
+    try:
+        return dir_handle.name()
+    except Exception:
+        return str(dir_handle)
+
+
+def list_devices() -> dict:
+    """Return a mapping of device name to its class name for all loaded devices."""
+    man = _manager()
+    devices = {}
+    for name in man.listDevices():
+        try:
+            devices[name] = type(man.getDevice(name)).__name__
+        except Exception as exc:
+            devices[name] = f"<error: {exc}>"
+    return devices
+
+
+def list_modules() -> dict:
+    """Return currently loaded and configured-but-unloaded module names."""
+    man = _manager()
+    return {
+        "loaded": list(man.listModules()),
+        "defined": list(man.listDefinedModules()),
+    }
+
+
+def manager_state() -> dict:
+    """Return a summary of Manager storage directories, counts, and config keys.
+
+    Deliberately excludes the module list; use list_modules for that.
+    """
+    man = _manager()
+    try:
+        current_dir = _dir_str(man.getCurrentDir())
+    except Exception:
+        current_dir = None
+    return {
+        "base_dir": _dir_str(man.getBaseDir()),
+        "current_dir": current_dir,
+        "device_count": len(man.listDevices()),
+        "config_keys": list(getattr(man, "config", {}).keys()),
+    }
+
+
+def get_log(lines: int = 50) -> dict:
+    """Return the last *lines* lines of the ACQ4 log file.
+
+    Returns a dict with keys `path` (the log file path or None) and `text`.
+    """
+    from acq4 import logging_config
+
+    handler = logging_config.log_file_handler
+    path = getattr(handler, "baseFilename", None) if handler is not None else None
+    if path is None:
+        return {"path": None, "text": "No log file is currently configured."}
+    try:
+        with open(path, "r", errors="replace") as f:
+            tail = f.readlines()[-lines:]
+    except OSError as exc:
+        return {"path": path, "text": f"Could not read log file: {exc}"}
+    return {"path": path, "text": "".join(tail)}

--- a/acq4/mcp/server.py
+++ b/acq4/mcp/server.py
@@ -1,0 +1,156 @@
+"""acq4-mcp: an MCP stdio server that executes code on a running ACQ4 over teleprox.
+
+Thin glue over acq4.mcp.connection.ConnectionManager. Only this module imports the
+optional `mcp` SDK (the ``acq4[mcp]`` extra), and it does so lazily inside
+build_server(); acq4.mcp.host and acq4.mcp.connection have no such dependency, so they
+import on every ACQ4 install. The teleprox port is supplied at runtime via the
+connect_acq4 tool (or a per-call port argument), so it can change without restarting.
+"""
+
+import argparse
+import json
+from typing import Optional
+
+from acq4.mcp.connection import ConnectionManager, NotConnectedError
+
+# One connection manager for the life of the server process; the active ACQ4 target is
+# chosen and can be re-pointed at runtime through the connect_acq4 tool.
+_connection = ConnectionManager()
+
+
+def _format_execute(result: dict) -> str:
+    """Render a host.execute result dict as readable text for the model."""
+    sections = []
+    if result.get("stdout"):
+        sections.append(f"stdout:\n{result['stdout'].rstrip()}")
+    if result.get("stderr"):
+        sections.append(f"stderr:\n{result['stderr'].rstrip()}")
+    if result.get("result") is not None:
+        sections.append(f"result: {result['result']}")
+    if result.get("traceback"):
+        sections.append(f"Traceback:\n{result['traceback'].rstrip()}")
+    if not sections:
+        return "(no output)"
+    return "\n\n".join(sections)
+
+
+def build_server():
+    """Construct and return the FastMCP server with all tools registered.
+
+    The `mcp` SDK is imported here (not at module import) so acq4.mcp.server can be
+    imported for its pure helpers even where the `mcp` extra is not installed.
+    """
+    from mcp.server.fastmcp import FastMCP
+
+    server = FastMCP("acq4")
+
+    @server.tool()
+    def connect_acq4(port: int, host: str = "127.0.0.1") -> str:
+        """Connect to a running ACQ4's teleprox server and make it the active target.
+
+        ACQ4 must have been started with `--teleprox <port>` (or `--teleprox` for a
+        random port, printed at startup as "Teleprox server listening on ..."). The
+        port can change between ACQ4 restarts; call this again with a new port to
+        re-point without restarting the MCP server. Returns an identity/sanity summary
+        (version, hostname, base dir, device count) so you can confirm the right rig.
+
+        host defaults to 127.0.0.1 (ACQ4 binds localhost); a remote rig needs an SSH
+        tunnel to that port.
+        """
+        return json.dumps(_connection.connect(port, host), indent=2, default=str)
+
+    @server.tool()
+    def execute_code(
+        code: str,
+        gui_thread: bool = False,
+        timeout: float = 30.0,
+        port: Optional[int] = None,
+        host: Optional[str] = None,
+    ) -> str:
+        """Execute arbitrary Python inside the running ACQ4 process and return its output.
+
+        The code runs in a fresh namespace (nothing persists between calls) seeded with
+        `man` (the ACQ4 Manager, via getManager()) and `acq4`. Captured stdout/stderr,
+        the value of a trailing expression (repr), and any traceback are returned.
+
+        SAFETY -- read this before mutating anything: inspect freely, but obtain
+        EXPLICIT USER APPROVAL before executing anything that changes running state or
+        moves hardware: stage/pipette moves, pressure changes, clamp mode changes,
+        starting tasks or acquisitions, or writing config/data. When unsure whether an
+        action mutates, treat it as mutating and ask first.
+
+        gui_thread selects where the code runs -- choosing wrong can crash or freeze
+        ACQ4:
+        * gui_thread=False (default): run off the GUI thread. Use for anything blocking
+          or long-running -- device moves, .wait(), acquisitions, sleeps, patch state
+          changes. Running these on the GUI thread would FREEZE or DEADLOCK ACQ4.
+        * gui_thread=True: marshal onto the Qt GUI thread and block until it returns.
+          Use ONLY for fast, non-blocking access to Qt widgets/objects or GUI state.
+          Touching Qt objects off the GUI thread risks a SEGFAULT, but never run
+          blocking work here.
+
+        port/host optionally override the active connection for this one call.
+        """
+        try:
+            result = _connection.execute(
+                code, gui_thread=gui_thread, timeout=timeout, port=port, host=host
+            )
+        except NotConnectedError as exc:
+            return f"Not connected: {exc}"
+        return _format_execute(result)
+
+    @server.tool()
+    def list_devices(port: Optional[int] = None, host: Optional[str] = None) -> str:
+        """Return the ACQ4 devices as a name -> device-class mapping (read-only)."""
+        try:
+            return json.dumps(
+                _connection.list_devices(port=port, host=host), indent=2, default=str
+            )
+        except NotConnectedError as exc:
+            return f"Not connected: {exc}"
+
+    @server.tool()
+    def list_modules(port: Optional[int] = None, host: Optional[str] = None) -> str:
+        """Return loaded and configured-but-unloaded ACQ4 module names (read-only)."""
+        try:
+            return json.dumps(
+                _connection.list_modules(port=port, host=host), indent=2, default=str
+            )
+        except NotConnectedError as exc:
+            return f"Not connected: {exc}"
+
+    @server.tool()
+    def manager_state(port: Optional[int] = None, host: Optional[str] = None) -> str:
+        """Return ACQ4 Manager storage dirs, device count, and config keys (read-only)."""
+        try:
+            return json.dumps(
+                _connection.manager_state(port=port, host=host), indent=2, default=str
+            )
+        except NotConnectedError as exc:
+            return f"Not connected: {exc}"
+
+    @server.tool()
+    def get_log(
+        lines: int = 50, port: Optional[int] = None, host: Optional[str] = None
+    ) -> str:
+        """Return the tail of the ACQ4 log file (read-only)."""
+        try:
+            log = _connection.get_log(lines=lines, port=port, host=host)
+        except NotConnectedError as exc:
+            return f"Not connected: {exc}"
+        return f"{log.get('path')}\n\n{log.get('text', '')}"
+
+    return server
+
+
+def main():
+    """Console-script entry point: run the acq4-mcp stdio server."""
+    parser = argparse.ArgumentParser(
+        description="MCP server for a running ACQ4 (via teleprox)."
+    )
+    parser.parse_args()
+    build_server().run()
+
+
+if __name__ == "__main__":
+    main()

--- a/acq4/mcp/tests/test_connection.py
+++ b/acq4/mcp/tests/test_connection.py
@@ -100,6 +100,49 @@ def test_list_devices_delegates_to_target(manager, recorder):
     assert recorder[-1][0] == "list_devices"
 
 
+def test_all_teleprox_access_serialized_onto_one_thread():
+    """Every teleprox call must run on a single dedicated thread, even under concurrent
+    callers, so one zmq client socket is never touched by two threads at once.
+    """
+    import threading
+
+    idents = []
+    idents_lock = threading.Lock()
+
+    class _IdentModule:
+        def __init__(self, host, port):
+            pass
+
+        def _record(self):
+            with idents_lock:
+                idents.append(threading.get_ident())
+
+        def instance_info(self, **kw):
+            self._record()
+            return {"has_manager": False}
+
+        def execute(self, code, gui_thread=False, **kw):
+            self._record()
+            return {"result": None}
+
+    cm = ConnectionManager(host_module_provider=lambda h, p: _IdentModule(h, p))
+    cm.connect(5000)
+
+    callers = [threading.Thread(target=lambda: cm.execute("1")) for _ in range(6)]
+    for t in callers:
+        t.start()
+    for t in callers:
+        t.join()
+
+    worker_idents = set(idents)
+    assert (
+        len(worker_idents) == 1
+    ), f"teleprox access spread across threads: {worker_idents}"
+    assert worker_idents != {
+        threading.get_ident()
+    }, "should run on a dedicated worker, not the caller"
+
+
 # ---------------------------------------------------------------------------
 # Live round-trip over a real teleprox child process (the same separate-process
 # model the MCP server uses in production, and teleprox's own reliable test pattern).

--- a/acq4/mcp/tests/test_connection.py
+++ b/acq4/mcp/tests/test_connection.py
@@ -1,0 +1,130 @@
+"""Tests for acq4.mcp.connection: the client-side teleprox connection manager.
+
+The bulk are deterministic unit tests using an injected fake host-module provider, so
+resolution, active-target tracking, port overrides, and delegation are covered without a
+live socket. A single module-scoped live test exercises the real teleprox round-trip.
+"""
+
+import pytest
+
+from acq4.mcp.connection import ConnectionManager, NotConnectedError
+
+
+class _FakeHostModule:
+    """Stand-in for the remote acq4.mcp.host proxy; records the target it was built for.
+
+    Methods accept and ignore teleprox call kwargs (_return_type, _timeout) the way the
+    real ObjectProxy would, and record them so tests can assert they were passed.
+    """
+
+    def __init__(self, recorder, host, port):
+        self.recorder = recorder
+        self.host = host
+        self.port = port
+
+    def instance_info(self, **kw):
+        self.recorder.append(("instance_info", self.host, self.port, kw))
+        return {"hostname": "fakerig", "has_manager": False, "device_count": None}
+
+    def execute(self, code, gui_thread=False, **kw):
+        self.recorder.append(("execute", self.host, self.port, code, gui_thread, kw))
+        return {
+            "stdout": "",
+            "stderr": "",
+            "result": repr(eval(code)),
+            "traceback": None,
+        }
+
+    def list_devices(self, **kw):
+        self.recorder.append(("list_devices", self.host, self.port, kw))
+        return {"cam": "MockCamera"}
+
+
+@pytest.fixture
+def recorder():
+    return []
+
+
+@pytest.fixture
+def manager(recorder):
+    return ConnectionManager(
+        host_module_provider=lambda h, p: _FakeHostModule(recorder, h, p)
+    )
+
+
+def test_execute_without_connection_raises(manager):
+    with pytest.raises(NotConnectedError):
+        manager.execute("1 + 1")
+
+
+def test_connect_returns_info_and_sets_active(manager):
+    info = manager.connect(5000)
+    assert info["host"] == "127.0.0.1"
+    assert info["port"] == 5000
+    assert info["hostname"] == "fakerig"
+    assert manager.active_address == "127.0.0.1:5000"
+
+
+def test_execute_uses_active_target(manager, recorder):
+    manager.connect(5000)
+    result = manager.execute("21 * 2")
+    assert result["result"] == "42"
+    execute_calls = [c for c in recorder if c[0] == "execute"]
+    assert execute_calls[0][1:3] == ("127.0.0.1", 5000)
+
+
+def test_explicit_port_overrides_without_prior_connect(manager, recorder):
+    result = manager.execute("'ok'", port=6000, host="10.0.0.5")
+    assert result["result"] == "'ok'"
+    assert recorder[-1][1:3] == ("10.0.0.5", 6000)
+
+
+def test_reconnect_updates_active_target(manager, recorder):
+    manager.connect(5000)
+    manager.connect(6000)
+    assert manager.active_address == "127.0.0.1:6000"
+    manager.execute("1 + 1")
+    assert recorder[-1][1:3] == ("127.0.0.1", 6000)
+
+
+def test_execute_passes_timeout_to_remote_call(manager, recorder):
+    manager.connect(5000)
+    manager.execute("1 + 1", timeout=99.0)
+    assert recorder[-1][5]["_timeout"] == 99.0
+
+
+def test_list_devices_delegates_to_target(manager, recorder):
+    manager.connect(5000)
+    devices = manager.list_devices()
+    assert devices == {"cam": "MockCamera"}
+    assert recorder[-1][0] == "list_devices"
+
+
+# ---------------------------------------------------------------------------
+# Live round-trip over a real teleprox child process (the same separate-process
+# model the MCP server uses in production, and teleprox's own reliable test pattern).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def child_process():
+    import teleprox
+
+    proc = teleprox.start_process(name="acq4-mcp-test")
+    yield proc
+    proc.stop()
+
+
+def _address_port(address):
+    return int(str(address).rsplit(":", 1)[1].rstrip("'\""))
+
+
+def test_live_connect_and_execute(child_process):
+    port = _address_port(child_process.client.address)
+    cm = ConnectionManager()
+    info = cm.connect(port)
+    assert info["port"] == port
+    assert info["has_manager"] is False  # no Manager in the bare child process
+    result = cm.execute("21 * 2")
+    assert result["result"] == "42"
+    assert result["traceback"] is None

--- a/acq4/mcp/tests/test_host.py
+++ b/acq4/mcp/tests/test_host.py
@@ -1,0 +1,217 @@
+"""Unit tests for acq4.mcp.host: the ACQ4-side code-execution and inspection helpers.
+
+These run without a live Manager or GUI; they exercise namespace seeding, output
+capture, exception reporting, and GUI-thread dispatch in isolation.
+"""
+
+import pytest
+
+from acq4.mcp import host
+
+
+def test_execute_returns_last_expression_repr():
+    result = host.execute("1 + 1")
+    assert result["result"] == "2"
+    assert result["traceback"] is None
+
+
+def test_execute_captures_stdout():
+    result = host.execute("print('hello world')")
+    assert "hello world" in result["stdout"]
+    # print() returns None, so there is no trailing-expression value
+    assert result["result"] is None
+
+
+def test_execute_multi_statement_with_trailing_expression():
+    result = host.execute("x = 5\nx * 2")
+    assert result["result"] == "10"
+
+
+def test_execute_no_trailing_expression_has_no_result():
+    result = host.execute("y = 41\ny += 1")
+    assert result["result"] is None
+    assert result["traceback"] is None
+
+
+def test_execute_reports_exception_traceback():
+    result = host.execute("raise ValueError('boom')")
+    assert result["result"] is None
+    assert "ValueError: boom" in result["traceback"]
+
+
+def test_execute_captures_stdout_before_exception():
+    result = host.execute("print('partial')\nraise RuntimeError('later')")
+    assert "partial" in result["stdout"]
+    assert "RuntimeError: later" in result["traceback"]
+
+
+def test_execute_seeds_acq4_module():
+    result = host.execute("acq4.__name__")
+    assert result["result"] == "'acq4'"
+
+
+def test_execute_seeds_man_as_none_without_manager():
+    # Without a running Manager, `man` is seeded as None rather than raising NameError.
+    result = host.execute("man is None")
+    assert result["result"] == "True"
+    assert result["traceback"] is None
+
+
+def test_execute_gui_thread_dispatches_through_run_in_gui_thread(monkeypatch):
+    from acq4.util import task
+
+    calls = []
+
+    def fake_run_in_gui_thread(fn, *args, **kwargs):
+        calls.append(fn)
+        return fn(*args, **kwargs)
+
+    monkeypatch.setattr(task, "run_in_gui_thread", fake_run_in_gui_thread)
+
+    result = host.execute("2 * 3", gui_thread=True)
+
+    assert calls, "expected gui_thread=True to route through run_in_gui_thread"
+    assert result["result"] == "6"
+
+
+def test_execute_default_does_not_use_gui_thread(monkeypatch):
+    from acq4.util import task
+
+    def boom(*args, **kwargs):
+        raise AssertionError(
+            "run_in_gui_thread must not be called when gui_thread=False"
+        )
+
+    monkeypatch.setattr(task, "run_in_gui_thread", boom)
+
+    result = host.execute("4 + 4")
+    assert result["result"] == "8"
+
+
+# ---------------------------------------------------------------------------
+# Read-only inspection helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeDir:
+    def __init__(self, path):
+        self._path = path
+
+    def name(self):
+        return self._path
+
+
+class _FakeManager:
+    def __init__(self):
+        self._devices = {"cam": object(), "stage": object()}
+        self.config = {"devices": {}, "storageDir": "/data", "misc": 1}
+
+    def listDevices(self):
+        return list(self._devices)
+
+    def getDevice(self, name):
+        return self._devices[name]
+
+    def listModules(self):
+        return ["Camera", "MultiPatch"]
+
+    def listDefinedModules(self):
+        return {"Camera": {}, "Console": {}}
+
+    def getBaseDir(self):
+        return _FakeDir("/data/base")
+
+    def getCurrentDir(self):
+        return _FakeDir("/data/base/2026.07.03")
+
+
+@pytest.fixture
+def fake_manager(monkeypatch):
+    import acq4
+
+    man = _FakeManager()
+    monkeypatch.setattr(acq4, "getManager", lambda: man)
+    return man
+
+
+def test_list_devices_maps_name_to_type(fake_manager):
+    devices = host.list_devices()
+    # each device object's class name is "object"
+    assert devices == {"cam": "object", "stage": "object"}
+
+
+def test_list_modules_reports_loaded_and_defined(fake_manager):
+    modules = host.list_modules()
+    assert modules["loaded"] == ["Camera", "MultiPatch"]
+    assert sorted(modules["defined"]) == ["Camera", "Console"]
+
+
+def test_manager_state_reports_dirs_and_counts(fake_manager):
+    state = host.manager_state()
+    assert state["base_dir"] == "/data/base"
+    assert state["current_dir"] == "/data/base/2026.07.03"
+    assert state["device_count"] == 2
+    assert "storageDir" in state["config_keys"]
+    # manager_state must not embed the module list (that is list_modules' job)
+    assert "modules" not in state
+
+
+def test_manager_state_handles_unset_current_dir(fake_manager, monkeypatch):
+    def raise_unset():
+        raise RuntimeError("Storage directory has not been set.")
+
+    monkeypatch.setattr(fake_manager, "getCurrentDir", raise_unset)
+    state = host.manager_state()
+    assert state["current_dir"] is None
+    assert state["base_dir"] == "/data/base"
+
+
+def test_get_log_tails_file(monkeypatch, tmp_path):
+    import types
+
+    import acq4.logging_config as lc
+
+    log = tmp_path / "acq4.log"
+    log.write_text("".join(f"line {i}\n" for i in range(100)))
+    monkeypatch.setattr(
+        lc, "log_file_handler", types.SimpleNamespace(baseFilename=str(log))
+    )
+
+    result = host.get_log(lines=5)
+    assert result["path"] == str(log)
+    assert result["text"].splitlines() == [
+        "line 95",
+        "line 96",
+        "line 97",
+        "line 98",
+        "line 99",
+    ]
+
+
+def test_get_log_without_handler_reports_no_file(monkeypatch):
+    import acq4.logging_config as lc
+
+    monkeypatch.setattr(lc, "log_file_handler", None)
+    result = host.get_log()
+    assert result["path"] is None
+    assert "no log file" in result["text"].lower()
+
+
+def test_instance_info_without_manager(monkeypatch):
+    import acq4
+
+    def raise_no_manager():
+        raise RuntimeError("No manager created yet")
+
+    monkeypatch.setattr(acq4, "getManager", raise_no_manager)
+    info = host.instance_info()
+    assert info["has_manager"] is False
+    assert info["device_count"] is None
+    assert "hostname" in info
+
+
+def test_instance_info_with_manager(fake_manager):
+    info = host.instance_info()
+    assert info["has_manager"] is True
+    assert info["device_count"] == 2
+    assert info["base_dir"] == "/data/base"

--- a/acq4/mcp/tests/test_server.py
+++ b/acq4/mcp/tests/test_server.py
@@ -1,0 +1,43 @@
+"""Tests for acq4.mcp.server's pure helpers.
+
+Importing this module must not require the optional `mcp` SDK; the SDK import is
+deferred into build_server(). These tests cover the result formatter only -- the thin
+FastMCP tool wiring is verified live against a running ACQ4.
+"""
+
+from acq4.mcp.server import _format_execute
+
+
+def test_format_includes_result_repr():
+    text = _format_execute(
+        {"stdout": "", "stderr": "", "result": "42", "traceback": None}
+    )
+    assert "42" in text
+
+
+def test_format_includes_stdout():
+    text = _format_execute(
+        {"stdout": "hello\n", "stderr": "", "result": None, "traceback": None}
+    )
+    assert "hello" in text
+
+
+def test_format_includes_stderr():
+    text = _format_execute(
+        {"stdout": "", "stderr": "a warning\n", "result": None, "traceback": None}
+    )
+    assert "a warning" in text
+
+
+def test_format_includes_traceback():
+    text = _format_execute(
+        {"stdout": "", "stderr": "", "result": None, "traceback": "ValueError: boom"}
+    )
+    assert "ValueError: boom" in text
+
+
+def test_format_empty_result_reports_no_output():
+    text = _format_execute(
+        {"stdout": "", "stderr": "", "result": None, "traceback": None}
+    )
+    assert "no output" in text.lower()

--- a/docs/superpowers/specs/2026-07-03-acq4-mcp-design.md
+++ b/docs/superpowers/specs/2026-07-03-acq4-mcp-design.md
@@ -1,0 +1,170 @@
+# acq4-mcp — MCP for executing code on a running ACQ4
+
+**Status:** Design approved (pending written-spec review)
+**Date:** 2026-07-03
+
+## Purpose
+
+Provide a Model Context Protocol (MCP) server that lets an AI client (Claude Desktop / Claude
+Code / etc.) inspect and drive a running ACQ4 instance by executing arbitrary Python inside the
+ACQ4 process. ACQ4 already exposes a teleprox `RPCServer` via its `--teleprox [port]` startup
+option; this MCP is a teleprox client that reaches that server, imports `acq4`, gets the
+`Manager`, and from there has full access to live rig state.
+
+The MCP ships with ACQ4 so it can be deployed on any production rig.
+
+## Background (verified against the codebase)
+
+- **Teleprox server** is started in `acq4/__main__.py`: when `--teleprox` is passed, an
+  `RPCServer` binds `tcp://127.0.0.1:*` (random port) or `tcp://127.0.0.1:<port>` and runs in a
+  background thread. It prints `Teleprox server listening on <address>`.
+- **Teleprox client API** (`teleprox/teleprox/client.py`, `proxy.py`): `RPCClient.get_client(address)`
+  returns a per-thread client; `client._import('acq4')` returns an `ObjectProxy`. Teleprox actions
+  are proxy operations only — `import`, `call_obj`, `get_obj`, `get_item`, `set_item`, `ping`,
+  `close`. **There is no built-in "exec a code string" action**, so arbitrary code text must be
+  run by a host-side helper that we ship.
+- **GUI-thread marshalling** lives in `acq4/util/task.py`: `run_in_gui_thread(fn, *args, **kwargs)`
+  runs `fn` on the Qt GUI thread and blocks for the result, or calls inline if already on the GUI
+  thread.
+- **Packaging**: `pyproject.toml` uses setuptools with `[project.optional-dependencies]` groups
+  (`nidaq`, `micromanager`, ...) and `[tool.setuptools] packages = find(include=["acq4*"])`. There
+  is no `[project.scripts]` section yet.
+
+## Architecture
+
+Two pieces, both inside the `acq4` package:
+
+```
+AI client (Claude)  --stdio-->  acq4-mcp server  --teleprox TCP-->  ACQ4 process
+                                (acq4/mcp/server.py)                 (RPCServer thread)
+                                                     imports & calls acq4/mcp/host.py
+```
+
+### Client side — `acq4/mcp/server.py`
+
+- A FastMCP **stdio** server built on the `mcp` Python SDK.
+- Holds a cache of teleprox `RPCClient`s keyed by `(host, port)` and tracks the **active**
+  connection.
+- Exposes the MCP tools (below). Each tool that needs ACQ4 resolves the target connection, does
+  `host = client._import('acq4.mcp.host')`, and calls a single host-side function — so one MCP
+  tool call is **one teleprox round-trip**, not dozens of proxied attribute accesses.
+- Entry point: `main()` (console script `acq4-mcp`).
+
+### ACQ4 side — `acq4/mcp/host.py`
+
+- A plain module present in **every** ACQ4 install. **No dependency on the `mcp` package** — pure
+  stdlib + acq4 — so it imports even on rigs where the `mcp` extra is not installed.
+- Contains the functions the server calls over teleprox:
+  - `execute(code, gui_thread=False)` — the workhorse (see below).
+  - `manager_state()`, `list_devices()`, `list_modules()`, `get_log(lines)` — read-only
+    inspection.
+- All real work (exec, stdout capture, GUI-thread dispatch) happens here, where the GUI and
+  Manager live.
+
+## Connection handling
+
+The teleprox port can change between ACQ4 restarts, and we do not want to restart the MCP each
+time. Therefore the port is supplied **during the conversation**, not fixed at MCP launch.
+
+- **`connect_acq4(port, host="127.0.0.1")`** — create/cache an `RPCClient` for that address, make
+  it the active connection, and return a sanity payload (ACQ4 version, hostname, config/base dir,
+  device count) so the caller can confirm the right rig.
+- Every other tool accepts an **optional** `port` (and `host`) override; absent that, it uses the
+  active connection. If there is no active connection and no `port`, the tool returns a clear
+  "call connect_acq4 first" error.
+- Re-point anytime by calling `connect_acq4` with a new port — **no MCP restart**. Cached clients
+  make re-connecting to a prior port instant.
+- Default `host` is `127.0.0.1`, matching ACQ4's bind. A remote rig requires an SSH tunnel; this
+  is documented, not automated.
+
+### Threading note (implementation constraint)
+
+Teleprox `RPCClient`s are per-thread. The MCP server must ensure a given client is used from a
+consistent thread (e.g. run tool bodies on a single worker thread, or key the client cache by
+thread as teleprox's `get_client` already does). This is called out so the implementation plan
+addresses it rather than discovering it at runtime.
+
+## Tool surface
+
+| Tool | Kind | Description |
+|------|------|-------------|
+| `connect_acq4(port, host="127.0.0.1")` | connection | Connect/re-point active ACQ4; returns sanity payload. |
+| `execute_code(code, gui_thread=False, timeout=30.0, port=None, host=None)` | exec | Run `code` host-side; return captured output + result. |
+| `list_devices(port=None, host=None)` | read-only | Device names and types. |
+| `list_modules(port=None, host=None)` | read-only | Loaded/available modules. |
+| `manager_state(port=None, host=None)` | read-only | Base/current dir, config summary (no module list). |
+| `get_log(lines=50, port=None, host=None)` | read-only | Tail of the ACQ4 log. |
+
+### `execute_code` semantics
+
+- Runs `code` host-side in a **fresh namespace per call** (stateless — no leakage between calls),
+  seeded with `man` (= `getManager()`) and `acq4`.
+- Captures `stdout` and `stderr` produced during execution.
+- Captures the value of the final expression, if the last statement is an expression, via `repr`
+  (REPL-like convenience).
+- On exception, returns the formatted traceback rather than raising across the MCP boundary.
+- Returns a text payload combining: captured stdout/stderr, the result repr, and any traceback.
+- `timeout` bounds the teleprox request; default 30.0s (teleprox's own default of 10s is too short
+  for some inspection).
+
+## GUI-thread policy (documented loudly)
+
+`execute_code` takes `gui_thread` (default `False`). Host-side, `execute` dispatches on it using
+`acq4.util.task.run_in_gui_thread`:
+
+- **`gui_thread=True`** → run via `run_in_gui_thread` (blocks the GUI thread until done). Use
+  **only** for: touching Qt widgets/objects, reading GUI state, or manager mutations that must
+  occur on the GUI thread. **Must be fast and non-blocking.**
+- **`gui_thread=False`** (default) → run directly on the teleprox handler thread. Use for anything
+  blocking or long: device moves, `.wait()`, acquisitions, `sleep`, patch state changes.
+
+**Failure modes, stated explicitly in the docs and the tool description:**
+
+- Touching Qt objects from a non-GUI thread risks a **segfault**.
+- Running blocking work on the GUI thread **freezes / deadlocks** the whole ACQ4 application.
+
+This is the central hazard the tool must teach its caller about.
+
+## Safety guidance (documentation only — not enforced)
+
+No code can reliably classify whether arbitrary Python mutates state, so there is **no enforcement
+layer**. Instead, guidance is placed where the agent reads it — the `execute_code` tool
+description and the README:
+
+> Inspect freely. Obtain **explicit user approval** before executing anything that mutates running
+> state or moves hardware — stage/pipette moves, pressure changes, clamp mode changes, starting
+> tasks/acquisitions, or writing config. When in doubt, treat it as mutating and ask first.
+
+The read-only helper tools (`list_devices`, `list_modules`, `manager_state`, `get_log`) are safe
+by construction and need no approval.
+
+## Packaging & distribution
+
+- New subpackage `acq4/mcp/`: `__init__.py`, `host.py`, `server.py`, `README.md`.
+- `pyproject.toml`:
+  - `[project.optional-dependencies]`: add `mcp = ["mcp"]`.
+  - `[project.scripts]`: add `acq4-mcp = "acq4.mcp.server:main"` (new section).
+- `host.py` has no `mcp` dependency, so it ships and imports on every ACQ4 install. Only the
+  machine running the MCP **server** needs `pip install acq4[mcp]`.
+- README includes a sample MCP client config snippet (`command: acq4-mcp`) and the SSH-tunnel note
+  for remote rigs.
+
+## Testing (TDD)
+
+- **Unit** (no teleprox, no GUI): import `acq4.mcp.host` directly and test `execute()` — stdout
+  capture, last-expression repr, exception/traceback formatting, namespace seeding (`man`/`acq4`),
+  and `gui_thread` dispatch (with `run_in_gui_thread` mocked). Test the read-only helpers against a
+  minimal/mocked Manager.
+- **Integration**: test the server's connection cache and active-connection logic against a real
+  in-process teleprox `RPCServer`.
+- **End-to-end / collaborative**: against a real ACQ4 launched with `--teleprox <port>`, connect
+  and exercise the tools interactively during development.
+
+## Out of scope (YAGNI)
+
+- Persistent cross-call exec namespace (explicitly chosen stateless).
+- Read-only / write-mode enforcement toggles or per-call confirm tokens.
+- Auto-discovery of the teleprox port.
+- Long-running networked (HTTP/SSE) MCP transport.
+- Rich structured per-operation tools (move_stage, get_frame, ...); `execute_code` is the escape
+  hatch.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
 
 [project.optional-dependencies]
 nidaq = ["pydaqmx"]
+mcp = ["mcp"]
 micromanager = ["pymmcore"]
 sensapex = ["sensapex"]
 scientifica = ["pyserial"]
@@ -87,6 +88,9 @@ docs = [
     "Sphinx>=4.1.2",
     "sphinx-rtd-theme>=0.5.2",
 ]
+
+[project.scripts]
+acq4-mcp = "acq4.mcp.server:main"
 
 [project.urls]
 Homepage = "http://www.acq4.org"


### PR DESCRIPTION
## What

Adds **acq4-mcp**, an MCP stdio server that lets an AI client inspect and drive a *running* ACQ4 instance by executing Python inside the ACQ4 process, over ACQ4's existing `--teleprox` RPCServer.

Design spec: `docs/superpowers/specs/2026-07-03-acq4-mcp-design.md`.

## Architecture (two-sided)

```
AI client --stdio--> acq4-mcp server --teleprox TCP--> ACQ4 process
          (mcp SDK)  (this package)                    (acq4.mcp.host)
```

- **`acq4/mcp/host.py`** — runs *inside* ACQ4 (Manager + Qt GUI). Does the exec + inspection. **No `mcp` dependency**, so it ships and imports on every ACQ4 install.
- **`acq4/mcp/connection.py`** — client-side teleprox connection manager. Port is supplied at runtime and re-pointable without restarting the server.
- **`acq4/mcp/server.py`** — thin FastMCP glue; imports the `mcp` SDK lazily in `build_server()`.

## Tools

- `connect_acq4(port, host)` — connect / re-point to a rig; returns an identity/sanity summary.
- `execute_code(code, gui_thread=False, timeout=30.0, port=None, host=None)` — arbitrary Python in a fresh namespace seeded with `man` and `acq4`; returns stdout/stderr, trailing-expression repr, and traceback.
- `list_devices`, `list_modules`, `manager_state`, `get_log` — read-only.

## GUI-thread policy (documented loudly)

- `gui_thread=False` (default): off the GUI thread — for anything blocking/long (moves, waits, acquisitions). Running these on the GUI thread would **freeze/deadlock** ACQ4.
- `gui_thread=True`: marshalled onto the Qt GUI thread — only for fast, non-blocking widget/GUI access. Touching Qt objects off-thread risks a **segfault**.

## Safety

Read-only helpers are free to call. `execute_code` guidance (in the tool docstring + README) instructs getting **explicit user approval before mutating state or moving hardware**. Not enforced — no code can reliably classify arbitrary Python.

## Packaging

- `acq4[mcp]` optional-dependency extra.
- `acq4-mcp` console script (`acq4.mcp.server:main`).

## Testing

TDD throughout. 31 tests in `acq4/mcp/tests/`:
- `test_host.py` — real in-process exec (output capture, trailing-expr repr, tracebacks, `man`/`acq4` seeding, gui_thread dispatch) + read-only helpers against a fake Manager.
- `test_connection.py` — deterministic connection-manager logic via an injected fake provider, plus one live round-trip over a real teleprox child process.
- `test_server.py` — pure result formatter; confirms the module imports without the `mcp` SDK.

Run: `pytest acq4/mcp/tests/` → 31 passed. black-clean.

**Not yet done:** end-to-end run of the actual MCP server against a live ACQ4 (`mcp` isn't installed in the dev env) — to be verified collaboratively.

🧙 Built with [WOZCODE](https://wozcode.com)