### PR TITLE
fix: address PR #551 review comments

### DIFF
--- a/acq4/devices/Pipette/calibration.py
+++ b/acq4/devices/Pipette/calibration.py
@@ -185,9 +185,8 @@ def scan_pipette_z_stack(pipette, imager=None, z_range=50e-6, z_step=5e-6, show=
         pipette_angle = np.arctan2(-image_dir[0], image_dir[1]) * 180 / np.pi
         px_size = frame.info()["pixelSize"][0]
 
-        result = do_pipette_tip_detection(img, pipette_angle, px_size, show=False)
-        image_pos_rc, z_um, confidence = result[:3]
-        heatmap = result[3].get('cropped_heatmap') if len(result) > 3 else None
+        image_pos_rc, z_um, confidence, _locals = do_pipette_tip_detection(img, pipette_angle, px_size, show=False)
+        heatmap = _locals.get('cropped_heatmap')
 
         tip_pos = frame.mapFromFrameToGlobal(pg.Vector(image_pos_rc))
         global_positions.append((tip_pos.x(), tip_pos.y(), tip_pos.z() + z_um * 1e-6))

--- a/acq4/devices/Pipette/calibration.py
+++ b/acq4/devices/Pipette/calibration.py
@@ -185,8 +185,9 @@ def scan_pipette_z_stack(pipette, imager=None, z_range=50e-6, z_step=5e-6, show=
         pipette_angle = np.arctan2(-image_dir[0], image_dir[1]) * 180 / np.pi
         px_size = frame.info()["pixelSize"][0]
 
-        image_pos_rc, z_um, confidence, _locals = do_pipette_tip_detection(img, pipette_angle, px_size, show=False)
-        heatmap = _locals.get('cropped_heatmap')
+        result = do_pipette_tip_detection(img, pipette_angle, px_size, show=False)
+        image_pos_rc, z_um, confidence = result[:3]
+        heatmap = result[3].get('cropped_heatmap') if len(result) > 3 else None
 
         tip_pos = frame.mapFromFrameToGlobal(pg.Vector(image_pos_rc))
         global_positions.append((tip_pos.x(), tip_pos.y(), tip_pos.z() + z_um * 1e-6))

--- a/acq4/devices/Pipette/pipette.py
+++ b/acq4/devices/Pipette/pipette.py
@@ -1054,14 +1054,17 @@ class Pipette(Device, OptomechDevice):
         frame_zs = global_positions[:, 2] - z_predictions_um * 1e-6
 
         # Discard frames where heatmap peak < 2 * heatmap stdev.
+        # keep-indices must stay aligned with frame_zs / z_predictions_um /
+        # global_positions, so we index into the original heatmaps list and skip
+        # (rather than filter out) frames with no heatmap instead of rebinding to
+        # a shorter list, which would misalign every subsequent index.
         keep = []
         if len(heatmaps) < 2:
             raise RuntimeError(f"Z-stack fallback: not enough frames ({len(heatmaps)}) to estimate tip position.")
-        heatmaps = [hm for hm in heatmaps if hm is not None]
-        if len(heatmaps) < 2:
-            raise RuntimeError(f"Z-stack fallback: heatmaps returned as None")
+        if sum(hm is not None for hm in heatmaps) < 2:
+            raise RuntimeError("Z-stack fallback: heatmaps returned as None")
         for i, hm in enumerate(heatmaps):
-            if hm.max() >= 2 * hm.std():
+            if hm is not None and hm.max() >= 2 * hm.std():
                 keep.append(i)
 
         if len(keep) < 2:

--- a/acq4/mcp/host.py
+++ b/acq4/mcp/host.py
@@ -7,6 +7,7 @@ inspection helpers.
 """
 
 import ast
+import collections
 import contextlib
 import io
 import traceback
@@ -39,6 +40,10 @@ def _exec_and_capture(code: str, namespace: dict) -> dict:
     result_repr = None
     tb = None
 
+    # redirect_stdout/redirect_stderr swap the process-global sys.stdout/sys.stderr, so
+    # for off-GUI (threaded) exec this also captures -- and thus steals -- concurrent
+    # print()s emitted by other threads while the code runs; their output may end up in
+    # this result or be lost from wherever it was meant to go.
     with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
         try:
             parsed = ast.parse(code)
@@ -178,7 +183,9 @@ def manager_state() -> dict:
 def get_log(lines: int = 50) -> dict:
     """Return the last *lines* lines of the ACQ4 log file.
 
-    Returns a dict with keys `path` (the log file path or None) and `text`.
+    Returns a dict with keys `path` (the log file path or None) and `text`. A
+    non-positive *lines* (0 or negative) means "no lines" and yields empty `text`
+    without touching the file.
     """
     from acq4 import logging_config
 
@@ -186,9 +193,14 @@ def get_log(lines: int = 50) -> dict:
     path = getattr(handler, "baseFilename", None) if handler is not None else None
     if path is None:
         return {"path": None, "text": "No log file is currently configured."}
+    if lines <= 0:
+        return {"path": path, "text": ""}
     try:
         with open(path, "r", errors="replace") as f:
-            tail = f.readlines()[-lines:]
+            # deque(maxlen=lines) keeps only the last `lines` lines in memory as it
+            # streams the file, rather than materializing the whole file into a list
+            # just to slice off the tail.
+            tail = collections.deque(f, maxlen=lines)
     except OSError as exc:
         return {"path": path, "text": f"Could not read log file: {exc}"}
     return {"path": path, "text": "".join(tail)}

--- a/acq4/mcp/server.py
+++ b/acq4/mcp/server.py
@@ -14,8 +14,18 @@ from typing import Optional
 from acq4.mcp.connection import ConnectionManager, NotConnectedError
 
 # One connection manager for the life of the server process; the active ACQ4 target is
-# chosen and can be re-pointed at runtime through the connect_acq4 tool.
-_connection = ConnectionManager()
+# chosen and can be re-pointed at runtime through the connect_acq4 tool. Constructed
+# lazily on first use (not at import) so that importing acq4.mcp.server for its pure
+# helpers does not build the ConnectionManager or its teleprox worker executor.
+_connection = None
+
+
+def _get_connection() -> ConnectionManager:
+    """Return the process-wide ConnectionManager, constructing it on first use."""
+    global _connection
+    if _connection is None:
+        _connection = ConnectionManager()
+    return _connection
 
 
 def _format_execute(result: dict) -> str:
@@ -57,7 +67,7 @@ def build_server():
         host defaults to 127.0.0.1 (ACQ4 binds localhost); a remote rig needs an SSH
         tunnel to that port.
         """
-        return json.dumps(_connection.connect(port, host), indent=2, default=str)
+        return json.dumps(_get_connection().connect(port, host), indent=2, default=str)
 
     @server.tool()
     def execute_code(
@@ -92,7 +102,7 @@ def build_server():
         port/host optionally override the active connection for this one call.
         """
         try:
-            result = _connection.execute(
+            result = _get_connection().execute(
                 code, gui_thread=gui_thread, timeout=timeout, port=port, host=host
             )
         except NotConnectedError as exc:
@@ -104,7 +114,9 @@ def build_server():
         """Return the ACQ4 devices as a name -> device-class mapping (read-only)."""
         try:
             return json.dumps(
-                _connection.list_devices(port=port, host=host), indent=2, default=str
+                _get_connection().list_devices(port=port, host=host),
+                indent=2,
+                default=str,
             )
         except NotConnectedError as exc:
             return f"Not connected: {exc}"
@@ -114,7 +126,9 @@ def build_server():
         """Return loaded and configured-but-unloaded ACQ4 module names (read-only)."""
         try:
             return json.dumps(
-                _connection.list_modules(port=port, host=host), indent=2, default=str
+                _get_connection().list_modules(port=port, host=host),
+                indent=2,
+                default=str,
             )
         except NotConnectedError as exc:
             return f"Not connected: {exc}"
@@ -124,7 +138,9 @@ def build_server():
         """Return ACQ4 Manager storage dirs, device count, and config keys (read-only)."""
         try:
             return json.dumps(
-                _connection.manager_state(port=port, host=host), indent=2, default=str
+                _get_connection().manager_state(port=port, host=host),
+                indent=2,
+                default=str,
             )
         except NotConnectedError as exc:
             return f"Not connected: {exc}"
@@ -135,7 +151,7 @@ def build_server():
     ) -> str:
         """Return the tail of the ACQ4 log file (read-only)."""
         try:
-            log = _connection.get_log(lines=lines, port=port, host=host)
+            log = _get_connection().get_log(lines=lines, port=port, host=host)
         except NotConnectedError as exc:
             return f"Not connected: {exc}"
         return f"{log.get('path')}\n\n{log.get('text', '')}"

--- a/acq4/mcp/tests/test_host.py
+++ b/acq4/mcp/tests/test_host.py
@@ -188,6 +188,40 @@ def test_get_log_tails_file(monkeypatch, tmp_path):
     ]
 
 
+def test_get_log_returns_only_last_n_lines(monkeypatch, tmp_path):
+    import types
+
+    import acq4.logging_config as lc
+
+    log = tmp_path / "acq4.log"
+    log.write_text("".join(f"line {i}\n" for i in range(10)))
+    monkeypatch.setattr(
+        lc, "log_file_handler", types.SimpleNamespace(baseFilename=str(log))
+    )
+
+    result = host.get_log(lines=2)
+    assert result["path"] == str(log)
+    assert result["text"].splitlines() == ["line 8", "line 9"]
+
+
+def test_get_log_zero_lines_returns_empty_text(monkeypatch, tmp_path):
+    # lines=0 means "no lines": empty text, not the whole file (a plain [-0:] slice
+    # would return everything).
+    import types
+
+    import acq4.logging_config as lc
+
+    log = tmp_path / "acq4.log"
+    log.write_text("".join(f"line {i}\n" for i in range(10)))
+    monkeypatch.setattr(
+        lc, "log_file_handler", types.SimpleNamespace(baseFilename=str(log))
+    )
+
+    result = host.get_log(lines=0)
+    assert result["path"] == str(log)
+    assert result["text"] == ""
+
+
 def test_get_log_without_handler_reports_no_file(monkeypatch):
     import acq4.logging_config as lc
 

--- a/acq4/modules/AutomationDebug/autopatch.py
+++ b/acq4/modules/AutomationDebug/autopatch.py
@@ -213,7 +213,11 @@ class Autopatcher:
 
     def _autopatchFindCell(self):
         win = self._window
-        if not win._unranked_cells:
+        # Keep imaging survey tiles until one yields a cell. An empty field of
+        # view is the common case, so it must advance to the next tile rather than
+        # end the survey; we only give up (return None) when nextTile() reports the
+        # region is fully imaged, there's no region, or we're out of cells.
+        while not win._unranked_cells:
             if self._outOfCells():
                 set_state("Autopatch: reached end of cell list; stopping")
                 return None
@@ -232,8 +236,6 @@ class Autopatcher:
             fut = win._detector._detectNeuronsZStack()
             fut.sigFinished.connect(win._detector._handleDetectResults)  # adds to win._unranked_cells
             fut.wait(timeout=600)
-            if not win._unranked_cells:
-                return None
 
         set_state("Autopatch: checking selected cell")
         cell = win._unranked_cells.pop(0)

--- a/acq4/modules/AutomationDebug/survey.py
+++ b/acq4/modules/AutomationDebug/survey.py
@@ -61,6 +61,16 @@ def plan_grid(
     return grid
 
 
+def _is_visited(
+    cx: float,
+    cy: float,
+    visited: list[tuple[float, float]],
+    threshold: float,
+) -> bool:
+    """Whether ``(cx, cy)`` lies within ``threshold`` of any visited center."""
+    return any(math.hypot(cx - vx, cy - vy) < threshold for vx, vy in visited)
+
+
 def select_next(
     grid: list[tuple[float, float]],
     visited: list[tuple[float, float]],
@@ -71,7 +81,7 @@ def select_next(
     Returns None when every planned tile has already been imaged.
     """
     for cx, cy in grid:
-        if not any(math.hypot(cx - vx, cy - vy) < threshold for vx, vy in visited):
+        if not _is_visited(cx, cy, visited, threshold):
             return (cx, cy)
     return None
 
@@ -82,11 +92,7 @@ def count_covered(
     threshold: float,
 ) -> int:
     """Number of centers in ``grid`` within ``threshold`` of some visited center."""
-    return sum(
-        1
-        for cx, cy in grid
-        if any(math.hypot(cx - vx, cy - vy) < threshold for vx, vy in visited)
-    )
+    return sum(1 for cx, cy in grid if _is_visited(cx, cy, visited, threshold))
 
 
 class SurveyRegion:
@@ -133,7 +139,10 @@ class SurveyRegion:
         self.clearRegion()
         cam = self._window.cameraDevice
         fov_w, fov_h = self._fov()
-        cx, cy = cam.globalCenterPosition()[:2]
+        # Center in "roi" mode so the default rectangle matches the imaged field:
+        # _fov() and detection use mode="roi", so this must too (globalCenterPosition
+        # defaults to mode="sensor", which is off-center for a cropped camera ROI).
+        cx, cy = cam.globalCenterPosition("roi")[:2]
         w, h = fov_w * 3, fov_h * 3
         pos = (cx - w / 2, cy - h / 2)
         roi = pg.RectROI(pos, (w, h), pen=pg.mkPen("y", width=2), removable=False)
@@ -149,6 +158,10 @@ class SurveyRegion:
     def clearRegion(self):
         """Remove the survey rectangle and forget imaged-tile progress."""
         if self._roi is not None:
+            try:
+                self._roi.sigRegionChanged.disconnect(self._window._refreshSurveyStats)
+            except (TypeError, RuntimeError):
+                pass
             self._cameraWindow().removeItem(self._roi)
             self._roi = None
         self._visited = []

--- a/acq4/modules/AutomationDebug/tests/test_survey.py
+++ b/acq4/modules/AutomationDebug/tests/test_survey.py
@@ -7,7 +7,12 @@ a user-defined region one z-stack per tile.
 
 import math
 
-from acq4.modules.AutomationDebug.survey import count_covered, plan_grid, select_next
+from acq4.modules.AutomationDebug.survey import (
+    _is_visited,
+    count_covered,
+    plan_grid,
+    select_next,
+)
 
 
 def _covers(grid, x0, y0, x1, y1, fov_w, fov_h):
@@ -65,6 +70,19 @@ def test_grid_centered_over_rect():
     ys = sorted({round(cy, 6) for _, cy in grid})
     assert math.isclose((xs[0] + xs[-1]) / 2, 125.0)
     assert math.isclose((ys[0] + ys[-1]) / 2, 65.0)
+
+
+def test_is_visited_false_when_nothing_visited():
+    assert _is_visited(0.0, 0.0, visited=[], threshold=1.0) is False
+
+
+def test_is_visited_true_within_threshold():
+    # A visited center a hair off the query point still counts as imaged.
+    assert _is_visited(0.0, 0.0, visited=[(0.3, 0.0)], threshold=1.0) is True
+
+
+def test_is_visited_false_outside_threshold():
+    assert _is_visited(0.0, 0.0, visited=[(10.0, 0.0)], threshold=1.0) is False
 
 
 def test_select_next_returns_first_when_nothing_visited():

--- a/acq4/modules/DataManager/FileDataView.py
+++ b/acq4/modules/DataManager/FileDataView.py
@@ -36,8 +36,8 @@ class FileDataView(Qt.QSplitter):
             self._current = fh
             self.displayMessage(
                 f"No file type could be detected for {fh.name()!r}.\n\n"
-                "A MultiPatch log must be named 'MultiPatch_*.log' (or have its "
-                "'__object_type__' recorded as 'MultiPatchLog' in the .index) to be "
+                "A MultiPatch log must be named like 'MultiPatch_*.log' (case-insensitive) "
+                "or have its '__object_type__' recorded as 'MultiPatchLog' in the .index to be "
                 "recognized by the data viewer."
             )
             return

--- a/tools/autopatch_analysis/autopatch_log.py
+++ b/tools/autopatch_analysis/autopatch_log.py
@@ -8,6 +8,7 @@ deriving how far each attempt progressed through the find/seal/break-in funnel.
 from __future__ import annotations
 
 import json
+import math
 import os
 from dataclasses import dataclass, field
 from typing import Any, Iterable
@@ -57,8 +58,10 @@ STATE_STAGE = {
     "collect": WHOLE_CELL,
 }
 
-# States that indicate an attempt has ended without a live whole-cell recording.
-FAILURE_STATES = frozenset({"broken", "fouled", "clean", "out", "bath", "blowout"})
+# Terminal reset states: the pipette parking in bath / out of the bath before or
+# after doing work. They are not a meaningful outcome, so ``outcome`` skips past
+# them to report the last state in which the attempt actually gave up.
+RESET_STATES = frozenset({"bath", "out"})
 
 
 def parse_log_events(path: str) -> list[dict[str, Any]]:
@@ -135,9 +138,10 @@ class Attempt:
         """'whole cell' on success, else the state the attempt gave up in."""
         if self.broke_in:
             return "whole cell"
-        # last failure/reset state entered, else the final state, else 'no states'
+        # last meaningful state entered (ignoring bath/out reset parking), else
+        # the final state if only reset states were seen, else 'no states'
         for _, state in reversed(self.states):
-            if state in FAILURE_STATES:
+            if state not in RESET_STATES:
                 return state
         return self.final_state or "no states"
 
@@ -174,6 +178,7 @@ class Attempt:
             tp["steady_state_resistance"]
             for tp in tps
             if tp.get("steady_state_resistance") is not None
+            and math.isfinite(tp["steady_state_resistance"])
         ]
         return max(vals) if vals else None
 
@@ -185,11 +190,19 @@ class Attempt:
 
     def _whole_cell_stat(self, field_name: str) -> float | None:
         tps = self.test_pulses_in_states({"whole cell"})
-        vals = [tp[field_name] for tp in tps if tp.get(field_name) is not None]
+        vals = [
+            tp[field_name]
+            for tp in tps
+            if tp.get(field_name) is not None and math.isfinite(tp[field_name])
+        ]
         if not vals:
             return None
         vals.sort()
-        return vals[len(vals) // 2]  # median
+        # true median: average the two middle values for an even-length list
+        mid = len(vals) // 2
+        if len(vals) % 2:
+            return vals[mid]
+        return (vals[mid - 1] + vals[mid]) / 2.0
 
     @property
     def access_resistance(self) -> float | None:

--- a/tools/autopatch_analysis/autopatch_metrics.py
+++ b/tools/autopatch_analysis/autopatch_metrics.py
@@ -109,7 +109,13 @@ def funnel_counts(df: pd.DataFrame) -> pd.DataFrame:
                 "pct_of_approached": (
                     (100.0 * count / approached) if approached else 0.0
                 ),
-                "conversion_from_prev": (100.0 * count / prev) if prev else 100.0,
+                # first stage is 100% by definition; a downstream stage whose
+                # predecessor had zero attempts converts at 0%, not 100%.
+                "conversion_from_prev": (
+                    100.0
+                    if prev is None
+                    else (100.0 * count / prev if prev else 0.0)
+                ),
             }
         )
         prev = count

--- a/tools/autopatch_analysis/tests/test_autopatch_log.py
+++ b/tools/autopatch_analysis/tests/test_autopatch_log.py
@@ -3,6 +3,7 @@
 Fixtures use real event-line shapes copied from actual MultiPatch_*.log files.
 """
 
+import math
 import os
 import sys
 
@@ -133,6 +134,101 @@ def test_never_found_cell(tmp_path):
     assert not a.attempted_find
     assert not a.found_cell
     assert a.outcome == "clean"
+
+
+def test_outcome_ignores_earlier_reset_states(tmp_path):
+    # Ends in a progress state after starting in bath; must report the progress
+    # state, not the earlier bath reset state.
+    path = _write(
+        tmp_path,
+        [
+            _state(0.0, "bath", "out"),
+            _state(5.0, "approach", "bath"),
+            _state(10.0, "seal", "approach"),
+        ],
+    )
+    a = al.load_log(path)[0]
+    assert a.outcome == "seal"
+
+
+def test_outcome_is_last_non_reset_state(tmp_path):
+    # A failure (broken) followed by a bath reset gives up in 'broken'.
+    path = _write(
+        tmp_path,
+        [
+            _state(0.0, "bath", "out"),
+            _state(5.0, "approach", "bath"),
+            _state(10.0, "broken", "approach"),
+            _state(15.0, "bath", "broken"),
+        ],
+    )
+    a = al.load_log(path)[0]
+    assert a.outcome == "broken"
+
+
+def test_outcome_only_reset_states_falls_back_to_final_state(tmp_path):
+    path = _write(tmp_path, [_state(0.0, "bath", "out"), _state(5.0, "out", "bath")])
+    a = al.load_log(path)[0]
+    assert a.outcome == "out"
+
+
+def test_outcome_no_states(tmp_path):
+    a = al.Attempt(
+        source="x", device="PatchPipette1", index=0, start_time=0.0, end_time=0.0
+    )
+    assert a.outcome == "no states"
+
+
+def test_max_seal_resistance_ignores_nan(tmp_path):
+    # A NaN test-pulse value must not defeat the real gigaohm reading.
+    a = al.Attempt(
+        source="x",
+        device="PatchPipette1",
+        index=0,
+        start_time=0.0,
+        end_time=40.0,
+        states=[(0.0, "bath"), (10.0, "seal")],
+        test_pulses=[
+            {"event_time": 15.0, "steady_state_resistance": float("nan")},
+            {"event_time": 20.0, "steady_state_resistance": 1.2e9},
+        ],
+    )
+    assert a.max_seal_resistance == pytest.approx(1.2e9)
+    assert a.gigaseal is True
+
+
+def test_whole_cell_stat_ignores_nan(tmp_path):
+    a = al.Attempt(
+        source="x",
+        device="PatchPipette1",
+        index=0,
+        start_time=0.0,
+        end_time=40.0,
+        states=[(0.0, "whole cell")],
+        test_pulses=[
+            {"event_time": 10.0, "access_resistance": float("nan")},
+            {"event_time": 20.0, "access_resistance": 12e6},
+        ],
+    )
+    assert a.access_resistance == pytest.approx(12e6)
+    assert math.isfinite(a.access_resistance)
+
+
+def test_whole_cell_stat_is_true_median_for_even_length(tmp_path):
+    a = al.Attempt(
+        source="x",
+        device="PatchPipette1",
+        index=0,
+        start_time=0.0,
+        end_time=40.0,
+        states=[(0.0, "whole cell")],
+        test_pulses=[
+            {"event_time": 10.0, "access_resistance": 10e6},
+            {"event_time": 20.0, "access_resistance": 20e6},
+        ],
+    )
+    # true median of [10e6, 20e6] is 15e6, not the upper-middle element (20e6)
+    assert a.access_resistance == pytest.approx(15e6)
 
 
 def test_approached_attempts_filters_out_never_approached(tmp_path):

--- a/tools/autopatch_analysis/tests/test_autopatch_metrics.py
+++ b/tools/autopatch_analysis/tests/test_autopatch_metrics.py
@@ -78,6 +78,24 @@ def test_funnel_is_based_on_approached_not_all_attempts():
     assert funnel.loc["broke_in", "conversion_from_prev"] == pytest.approx(50.0)
 
 
+def test_funnel_conversion_from_zero_prev_is_zero():
+    # A single attempt that approached but never found a cell: found_cell count
+    # is 0, so sealed/broke_in have a zero-count predecessor. Their conversion
+    # from the previous stage must be 0.0, not 100.0.
+    attempts = [_attempt(0, [(0.0, "bath"), (1.0, "approach")])]
+    df = am.attempts_to_dataframe(attempts)
+    funnel = am.funnel_counts(df).set_index("stage")
+    assert funnel.loc["approached", "count"] == 1
+    assert funnel.loc["found_cell", "count"] == 0
+    assert funnel.loc["sealed", "count"] == 0
+    # first stage is always 100%; downstream stages with a 0-count predecessor
+    # convert at 0%, not 100%.
+    assert funnel.loc["approached", "conversion_from_prev"] == pytest.approx(100.0)
+    assert funnel.loc["found_cell", "conversion_from_prev"] == pytest.approx(0.0)
+    assert funnel.loc["sealed", "conversion_from_prev"] == pytest.approx(0.0)
+    assert funnel.loc["broke_in", "conversion_from_prev"] == pytest.approx(0.0)
+
+
 def test_state_timeline_spans_per_folder():
     attempts = _sample_attempts()
     tl = am.state_timeline(attempts)


### PR DESCRIPTION
Follow-up fixes for the code review on acq4/acq4#551. Targets `_gentlestaging` so it folds into that PR.

## High
- **Survey tiling aborts on first empty FOV** — `AutomationDebug/autopatch.py`. `_autopatchFindCell` returned `None` both for "this tile had no cells" and "region fully imaged", and the caller treats `None` as "quit demo" — so the first empty field of view ended the whole survey (the headline feature never tiled). Now loops nextTile→move→detect, only returning `None` when `nextTile()` reports the region is exhausted (or there's no region / out of cells).
- **Heatmap index misalignment** — `Pipette/pipette.py`. `_findTipViaZStack` rebuilt `keep` indices from a `None`-filtered heatmap list but applied them to the unfiltered `frame_zs`/`z_predictions_um`/`global_positions` arrays, silently fitting mismatched pairs. Now indexes the original arrays and skips `None` in place. (Latent today, since heatmaps are always real arrays — but the diff added the `None`-handling and got it wrong.)
- **`outcome` mislabels stalled attempts as `bath`/`out`** — `autopatch_analysis/autopatch_log.py`. `bath`/`out` are the normal *starting* states, so any attempt ending mid-progress reported `"bath"`. Now returns the last non-reset state; `bath`/`out` are treated as terminal parking, not an outcome.

## Medium
- **`get_log` reads the whole file; `lines=0` dumped everything** — `mcp/host.py`. Streams the tail via `deque(maxlen=lines)`; `lines<=0` now means "no lines".
- **Survey rectangle centered in wrong FOV mode** — `AutomationDebug/survey.py`. `globalCenterPosition()` defaults to `mode="sensor"`; `_fov()`/detection use `"roi"`. Now centers in `"roi"`.
- **Funnel conversion 100%-when-zero** — `autopatch_analysis/autopatch_metrics.py`. `conversion_from_prev` now reports 0% (not 100%) when the previous stage count is zero; 100% only for the root stage.
- **NaN test-pulse values defeat seal/quality stats** — `autopatch_log.py`. Filters non-finite values so `max([nan, 1e9])` can't hide a real gigaohm seal.

## Low
- `autopatch_log.py`: `_whole_cell_stat` now computes a true median (was upper-middle element, disagreeing with the notebook's `pandas.median()`).
- `survey.py`: disconnect `sigRegionChanged` in `clearRegion`; dedupe the visited-tile predicate into `_is_visited`.
- `mcp/host.py`: comment noting exec stdout/stderr redirection is process-global.
- `mcp/server.py`: construct the module-level `ConnectionManager` lazily so importing for pure helpers has no side effects.

## Not changed (verified against source)
- **`__main__.py` teleprox "never started"** (Copilot) — `RPCServer(run_thread=True)` starts its own daemon thread; an explicit start would double-start it (the review flagged this as a hallucination; matches @outofculture's reply).
- **`calibration.py` 4-value unpack** (Copilot) — `do_pipette_tip_detection` always returns a 4-tuple; the review flagged the ValueError concern as a hallucination. (An earlier speculative defensive-unpack commit here is reverted in this PR.)

## Deferred lows (left as-is; noted for a fast-follow, not fixed here)
- `survey.py` `nextTile` marks a tile visited before the move/acquire succeeds — a failed tile is skipped on retry (debatable; retrying forever is worse).
- `autopatch.py` `_outOfCells` surveys even with "find more cells" unchecked before any cell is worked — likely by-design (the survey region is itself the opt-in); worth @outofculture confirming.
- `autopatch_log.py` `load_log` creates empty attempts for non-pipette devices (hidden by the notebook's `DROP_EMPTY_ATTEMPTS`).
- Notebook `sys.path.insert(0, '.')` breaks if launched from repo root.

## Verification
- `pytest tools/autopatch_analysis/tests acq4/modules/AutomationDebug/tests/test_survey.py acq4/mcp/tests` → **76 passed**, no warnings.
- `py_compile` clean on all touched source files. Device code (`autopatch.py`, `pipette.py`) has no unit-test harness (hardware/GUI-coupled); changes were kept minimal and reviewed against the report.

🧙 Built with [WOZCODE](https://wozcode.com)